### PR TITLE
fix: use old version of cozy-konnector-libs and pdfjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,13 +32,13 @@
     "travisDeployKey": "./bin/generate_travis_deploy_key"
   },
   "dependencies": {
-    "cozy-konnector-libs": "4.5.2",
-    "pdfjs": "2.0.0-alpha.8"
+    "cozy-konnector-libs": "4.4.0",
+    "pdfjs": "2.0.0-alpha.7"
   },
   "devDependencies": {
     "copy-webpack-plugin": "4.5.1",
     "cozy-app-publish": "0.3.6",
-    "cozy-jobs-cli": "1.3.3",
+    "cozy-jobs-cli": "1.3.0",
     "eslint": "4.19.1",
     "eslint-config-cozy-app": "0.8.0",
     "git-directory-deploy": "1.5.1",

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,7 @@
+process.env.SENTRY_DSN =
+  process.env.SENTRY_DSN ||
+  'https://a549306c82814cb8a1118c1695718eee:ed5e5794595a4182acf408de4e088037@sentry.cozycloud.cc/37'
+
 const {
   BaseKonnector,
   requestFactory,
@@ -7,10 +11,6 @@ const {
   scrape,
   saveBills
 } = require('cozy-konnector-libs')
-
-process.env.SENTRY_DSN =
-  process.env.SENTRY_DSN ||
-  'https://a549306c82814cb8a1118c1695718eee:ed5e5794595a4182acf408de4e088037@sentry.cozycloud.cc/37'
 
 // cheerio & moment are dependencies from cozy-konnect-libs
 const moment = require('moment')

--- a/yarn.lock
+++ b/yarn.lock
@@ -1153,26 +1153,47 @@ cozy-client-js@0.9.0, cozy-client-js@^0.9.0:
   dependencies:
     core-js "^2.5.3"
     pouchdb "6.1.1"
-    pouchdb-adapter-cordova-sqlite "git+https://github.com/SnceGroup/pouchdb-adapter-cordova-sqlite.git#f3ee23009b70209c611435d57491aa77fb88802a"
+    pouchdb-adapter-cordova-sqlite "https://github.com/SnceGroup/pouchdb-adapter-cordova-sqlite.git#f3ee23009b70209c611435d57491aa77fb88802a"
     pouchdb-find "0.10.4"
 
-cozy-jobs-cli@1.3.3:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/cozy-jobs-cli/-/cozy-jobs-cli-1.3.3.tgz#3c3819eb49b8e134cdde5f785856fdc57ce499dd"
+cozy-jobs-cli@1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/cozy-jobs-cli/-/cozy-jobs-cli-1.3.0.tgz#e63515c56076f1ef109ec2cebec33fb16f5c3aae"
   dependencies:
     btoa "^1.1.2"
     cheerio "^1.0.0-rc.2"
     commander "^2.12.2"
     core-js "2.5.7"
     cozy-client-js "^0.9.0"
-    cozy-konnector-libs "^4.5.2"
-    cozy-logger "^1.1.8"
+    cozy-konnector-libs "^4.4.0"
+    cozy-logger "^1.1.7"
     isomorphic-fetch "^2.2.1"
     opn "5.3.0"
     regenerator-runtime "^0.11.1"
     replay "2.3.0"
 
-cozy-konnector-libs@4.5.2, cozy-konnector-libs@^4.5.2:
+cozy-konnector-libs@4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/cozy-konnector-libs/-/cozy-konnector-libs-4.4.0.tgz#e69e347f562bba941b3d7d8759a774309cb3367f"
+  dependencies:
+    bluebird "3.5.1"
+    bluebird-retry "0.11.0"
+    btoa "1.2.1"
+    cheerio "1.0.0-rc.2"
+    cozy-client-js "0.9.0"
+    cozy-logger "^1.1.7"
+    date-fns "1.29.0"
+    geco "0.11.1"
+    lodash "4.17.10"
+    moment "2.22.2"
+    pdfjs "2.0.0-alpha.8"
+    raven "2.6.2"
+    request "2.87.0"
+    request-debug "0.2.0"
+    request-promise "4.2.2"
+    uuid "3.2.1"
+
+cozy-konnector-libs@^4.4.0:
   version "4.5.2"
   resolved "https://registry.yarnpkg.com/cozy-konnector-libs/-/cozy-konnector-libs-4.5.2.tgz#741c2e8d109b21b84cac3f6cafb6a9afdab70728"
   dependencies:
@@ -1193,7 +1214,7 @@ cozy-konnector-libs@4.5.2, cozy-konnector-libs@^4.5.2:
     request-promise "4.2.2"
     uuid "3.2.1"
 
-cozy-logger@^1.1.8:
+cozy-logger@^1.1.7, cozy-logger@^1.1.8:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/cozy-logger/-/cozy-logger-1.1.8.tgz#4ef7f009b7e63f6d0e1d8515e3758ffa351ea16e"
   dependencies:
@@ -3975,6 +3996,16 @@ pbkdf2@^3.0.3:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
+pdfjs@2.0.0-alpha.7:
+  version "2.0.0-alpha.7"
+  resolved "https://registry.yarnpkg.com/pdfjs/-/pdfjs-2.0.0-alpha.7.tgz#43298e8b708ff3d1e16106622bb8389dbd026641"
+  dependencies:
+    "@rkusa/linebreak" "^1.0.0"
+    opentype.js "^0.7.3"
+    pako "^1.0.6"
+    unorm "^1.4.1"
+    uuid "^3.0.1"
+
 pdfjs@2.0.0-alpha.8:
   version "2.0.0-alpha.8"
   resolved "https://registry.yarnpkg.com/pdfjs/-/pdfjs-2.0.0-alpha.8.tgz#47754b862602fc6a1435a08c1ea718d36906447e"
@@ -4033,10 +4064,9 @@ posix-character-classes@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
 
-"pouchdb-adapter-cordova-sqlite@git+https://github.com/SnceGroup/pouchdb-adapter-cordova-sqlite.git#f3ee23009b70209c611435d57491aa77fb88802a":
+"pouchdb-adapter-cordova-sqlite@https://github.com/SnceGroup/pouchdb-adapter-cordova-sqlite.git#f3ee23009b70209c611435d57491aa77fb88802a":
   version "2.0.2"
-  uid f3ee23009b70209c611435d57491aa77fb88802a
-  resolved "git+https://github.com/SnceGroup/pouchdb-adapter-cordova-sqlite.git#f3ee23009b70209c611435d57491aa77fb88802a"
+  resolved "https://github.com/SnceGroup/pouchdb-adapter-cordova-sqlite.git#f3ee23009b70209c611435d57491aa77fb88802a"
   dependencies:
     pouchdb-adapter-websql-core "^6.1.1"
 


### PR DESCRIPTION
pdfjs : there was a font error message :
TypeError: Cannot read property 'slice' of undefined
    at new OTFFontFactory (/home/doubleface/Workspace/connectors/booking.com/node_modules/pdfjs/lib/font/otf.js:19:25)
    at Object.<anonymous> (/home/doubleface/Workspace/connectors/booking.com/src/html2pdf.js:4:23)
    at Module._compile (module.js:635:30)
    at Object.Module._extensions..js (module.js:646:10)
    at Module.load (module.js:554:32)
    at tryModuleLoad (module.js:497:12)
    at Function.Module._load (module.js:489:3)
    at Module.require (module.js:579:17)
    at require (internal/module.js:11:18)
    at Object.<anonymous> (/home/doubleface/Workspace/connectors/booking.com/src/index.js:21:18)
    at Module._compile (module.js:635:30)
    at Object.Module._extensions..js (module.js:646:10)
    at Module.load (module.js:554:32)
    at tryModuleLoad (module.js:497:12)
    at Function.Module._load (module.js:489:3)

cozy-konnector-libs : regression on requestFactory, no more bills found